### PR TITLE
fix: Required codeowners on PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joswayski


### PR DESCRIPTION
Let's see if this works