### PR TITLE
chore: Login links are suspended if key is modified

### DIFF
--- a/utils/loginLinks/updateLoginLink.ts
+++ b/utils/loginLinks/updateLoginLink.ts
@@ -1,0 +1,54 @@
+import { UpdateCommand, UpdateCommandInput } from "@aws-sdk/lib-dynamodb";
+import { Dynamo } from "../../libs/ddbDocClient";
+const { DYNAMO_TABLE_NAME } = process.env;
+
+// Allows updating the login link status for suspending it incase of malicious actors
+export default async function UpdateLoginLink({
+  user_id,
+  login_link_timestamp,
+  updated_login_link,
+}) {
+  // TODO user the cleaning functions instead
+  const FORBIDDEN_KEYS = [
+    "PK",
+    "SK",
+    "login_link_hash",
+    "entity_type",
+    "created_at",
+    "user_id",
+    "expires_at",
+    "ttl_expiry",
+  ];
+
+  const incomingKeys = Object.keys(updated_login_link);
+  const newKeys = incomingKeys.filter((key) => !FORBIDDEN_KEYS.includes(key));
+
+  // Build update expression
+  let newUpdateExpression: string[] = [];
+  let newAttributes: any = {};
+
+  newKeys.forEach((key) => {
+    newUpdateExpression.push(`${key} = :${key}`);
+    newAttributes[`:${key}`] = updated_login_link[key];
+  });
+
+  const UpdatedExpression = `SET ${newUpdateExpression.join(", ").toString()}`;
+
+  const params: UpdateCommandInput = {
+    Key: {
+      PK: `USER#${user_id}`,
+      SK: `LOGIN_LINK#${login_link_timestamp}`,
+    },
+    UpdateExpression: UpdatedExpression,
+    ExpressionAttributeValues: newAttributes,
+    TableName: DYNAMO_TABLE_NAME,
+    ConditionExpression: "attribute_exists(PK)",
+  };
+
+  try {
+    await Dynamo.send(new UpdateCommand(params));
+    return;
+  } catch (error) {
+    throw new Error(error);
+  }
+}


### PR DESCRIPTION
Let's say your login link is: `plutomi.com/login?user_id=hei1u2&key=123`

If you:
1. Somehow guess another person's ID
2. And try to login in the 15 minute period that their key is valid
3. Fuck up the key

The key is immediately invalidated and cannot be used to sign in. You must wait the X minutes to create another key.

I do not envision a scenario in which a normal user would take the key sent to them and modify it in any way. We should assume that any key modification is a malicious user. This is essentially bcrypt on steroids, with one guess every 10 minutes for a 1500 char key. And since the key changes each time... good luck!

Also closes #68