### PR TITLE
fix: Team page not showing all users in org, fix orgId not found

### DIFF
--- a/pages/api/orgs/[orgId]/index.ts
+++ b/pages/api/orgs/[orgId]/index.ts
@@ -15,7 +15,7 @@ const handler = async (
   const { method, query } = req; // TODO user type
   const { orgId } = query as Pick<CUSTOM_QUERY, "orgId">;
 
-  const org = await getOrg(orgId);
+  const org = await getOrg({ orgId: orgId });
 
   if (method === API_METHODS.GET) {
     // When signed in, this returns all data for an org

--- a/pages/api/orgs/[orgId]/users.ts
+++ b/pages/api/orgs/[orgId]/users.ts
@@ -16,7 +16,6 @@ const handler = async (
 
   if (method === API_METHODS.GET) {
     if (req.session.user.orgId != orgId) {
-      // TODO team site bug returning 403 -- TODO I think this is fixed
       return res
         .status(403)
         .json({ message: "You cannot view the users of this org" });
@@ -29,7 +28,9 @@ const handler = async (
     }
 
     try {
-      const allUsers = await getAllUsersInOrg(req.session.user.orgId);
+      const allUsers = await getAllUsersInOrg({
+        orgId: req.session.user.orgId,
+      });
       return res.status(200).json(allUsers);
     } catch (error) {
       return res


### PR DESCRIPTION
Side effect of functions needed an object as input and defaults using single variables