### PR TITLE
fix: Docker & outDir (`dist`) compatability 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ Thumbs.db
 .env
 .env.development
 .env.test
+*.env
 tests/
 __tests__/
 .next

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,6 @@ COPY --from=builder /app/packages/api/package.json packages/api/package.json
 # And the node modules
 COPY --from=builder /app/packages/api/node_modules packages/api/node_modules
 
-# Delete all unecessary .ts files
-# RUN rm *.ts 
-
 # Copy starting scripts
 COPY --from=builder /app/package.json package.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,8 @@ WORKDIR /app
 
 ENV NODE_ENV production
 
-# Setting any environment variables that Next FE needs
-# Commits token is SSR'd on the homepage TODO
-# ARG COMMITS_TOKEN 
-# ARG NEXT_PUBLIC_DEPLOYMENT_ENVIRONMENT
-# ARG NEXT_PUBLIC_WEBSITE_URL
-
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED 1
-
+# Disable telemetry during runtime.
+ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -47,8 +40,18 @@ RUN adduser --system --uid 1001 nextjs
 # Copying public NextJS assets
 COPY --from=builder /app/packages/web/public packages/web/public
 
-# Copy API files
-COPY --from=builder /app/packages/api packages/api
+# Copy API files that were built
+# Modify the outDir tsconfig file in packages/api if you want to change this
+COPY --from=builder /app/packages/api/dist packages/api
+
+# Copy the package.json so that the API can be run
+COPY --from=builder /app/packages/api/package.json packages/api/package.json
+
+# And the node modules
+COPY --from=builder /app/packages/api/node_modules packages/api/node_modules
+
+# Delete all unecessary .ts files
+# RUN rm *.ts 
 
 # Copy starting scripts
 COPY --from=builder /app/package.json package.json

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -5,7 +5,9 @@ import compression from "compression";
 import path from "path";
 
 const dev = env.NODE_ENV !== "production";
-const webApp = next({ dev, dir: path.resolve(__dirname, "../web") });
+
+const dir = path.join(__dirname, "../web");
+const webApp = next({ dev, dir });
 const nextHandler = webApp.getRequestHandler();
 
 (async () => {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -2,7 +2,7 @@
   "name": "@plutomi/api",
   "version": "0.1.0",
   "description": "API Package for Plutomi.",
-  "main": "dist/index.js",
+  "main": "index.js",
   "repository": "https://github.com/plutomi/plutomi",
   "author": "Plutomi Inc.",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node index.js"
   },
   "devDependencies": {
     "@types/compression": "^1.7.2",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -49,6 +49,8 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // ! Note: Make sure to update the dockerfile if you change the outDir.
+    // We are purposely excluding all .ts files for a smaller image size.
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */


### PR DESCRIPTION
Only copying over what is needed, moving the  `dist` to the root of `packages/api` so there isn't any funkyness with path.join