### PR TITLE
Adding back raw entity to multi-key index

### DIFF
--- a/packages/api/controllers/totp/post.ts
+++ b/packages/api/controllers/totp/post.ts
@@ -81,6 +81,10 @@ export const post: RequestHandler = async (req, res) => {
       entityType: IdPrefix.USER,
       relatedTo: [
         {
+          id: IdPrefix.USER,
+          type: RelatedToType.ENTITY
+        },
+        {
           id: userId,
           type: RelatedToType.SELF
         },
@@ -209,6 +213,10 @@ export const post: RequestHandler = async (req, res) => {
         .toISOString(),
       status: TOTPCodeStatus.ACTIVE,
       relatedTo: [
+        {
+          id: IdPrefix.TOTP,
+          type: RelatedToType.ENTITY
+        },
         {
           id: totpCodeId,
           type: RelatedToType.SELF

--- a/packages/api/controllers/waitlist/post.ts
+++ b/packages/api/controllers/waitlist/post.ts
@@ -33,6 +33,10 @@ export const post: RequestHandler = async (req, res) => {
       updatedAt: nowIso,
       relatedTo: [
         {
+          id: IdPrefix.WAIT_LIST_USER,
+          type: RelatedToType.ENTITY
+        },
+        {
           id: userId,
           type: RelatedToType.SELF
         },

--- a/packages/api/controllers/waitlist/post.ts
+++ b/packages/api/controllers/waitlist/post.ts
@@ -1,7 +1,12 @@
 import type { RequestHandler } from "express";
 import { Schema, validate } from "@plutomi/validation";
 import dayjs from "dayjs";
-import { IdPrefix, type Email, RelatedToType } from "@plutomi/shared";
+import {
+  IdPrefix,
+  RelatedToType,
+  type WaitListUser,
+  type Email
+} from "@plutomi/shared";
 import { generatePlutomiId } from "../../utils";
 
 export const post: RequestHandler = async (req, res) => {
@@ -25,7 +30,7 @@ export const post: RequestHandler = async (req, res) => {
       entity: IdPrefix.WAIT_LIST_USER
     });
 
-    await req.items.insertOne({
+    const waitListUser: WaitListUser = {
       _id: userId,
       entityType: IdPrefix.WAIT_LIST_USER,
       email: email as Email,
@@ -39,13 +44,10 @@ export const post: RequestHandler = async (req, res) => {
         {
           id: userId,
           type: RelatedToType.SELF
-        },
-        {
-          id: email as Email,
-          type: RelatedToType.WAIT_LIST_USERS
         }
       ]
-    });
+    };
+    await req.items.insertOne(waitListUser);
 
     res.status(201).json({
       message:

--- a/packages/api/utils/sessions/createSession.ts
+++ b/packages/api/utils/sessions/createSession.ts
@@ -44,6 +44,10 @@ export const createSession = async ({
     userAgent,
     relatedTo: [
       {
+        id: IdPrefix.SESSION,
+        type: RelatedToType.ENTITY
+      },
+      {
         id: sessionId,
         type: RelatedToType.SELF
       },

--- a/packages/shared/@types/entities/baseEntity.ts
+++ b/packages/shared/@types/entities/baseEntity.ts
@@ -6,6 +6,7 @@ export type BaseEntity<T extends IdPrefix> = {
   _id: PlutomiId<T>;
   createdAt: string;
   updatedAt: string;
+  // This is the external name so it is easier to work with
   entityType: T;
   relatedTo: RelatedToArray<T>;
 };

--- a/packages/shared/@types/entities/waitListUser.ts
+++ b/packages/shared/@types/entities/waitListUser.ts
@@ -1,12 +1,12 @@
 import type { Email } from "../email";
-import type { RelatedToType, RelatedToArray } from "../indexableProperties";
+import type { RelatedToArray } from "../indexableProperties";
 import type { IdPrefix } from "./idPrefix";
 import type { BaseEntity } from "./baseEntity";
 
 type WaitListUserRelatedToArray = [
-  ...RelatedToArray<IdPrefix.WAIT_LIST_USER>,
+  ...RelatedToArray<IdPrefix.WAIT_LIST_USER>
   // Get a user by email
-  { id: Email; type: RelatedToType.WAIT_LIST_USERS }
+  // { id: Email; type: RelatedToType.WAIT_LIST_USERS }
 ];
 
 export type WaitListUser = BaseEntity<IdPrefix.WAIT_LIST_USER> & {

--- a/packages/shared/@types/indexableProperties.ts
+++ b/packages/shared/@types/indexableProperties.ts
@@ -12,13 +12,18 @@ export enum RelatedToType {
   WAIT_LIST_USERS = "waitListUsers",
   TOTPS = "totps",
   SESSIONS = "sessions",
+  // NOTES = "notes",
+  // FILES = "files",
+  // MEMBERSHIPS = "memberships",
+  // INVITES = "invites",
+  // TASKS = "tasks",
+  // ACTIVITY = "activity"
+
+
+  // These are metadata and are not directly related to parent <> child relationships
   SELF = "self",
-  NOTES = "notes",
-  FILES = "files",
-  MEMBERSHIPS = "memberships",
-  INVITES = "invites",
-  TASKS = "tasks",
-  ACTIVITY = "activity"
+  ENTITY = "entity"
+
 }
 
 // These can be anything
@@ -50,6 +55,7 @@ type OtherRelatedToArrayItems = {
  */
 export type RelatedToArray<T extends IdPrefix> = [
   // These two will always be the first two items
+  { id: T; type: RelatedToType.ENTITY },
   { id: PlutomiId<T>; type: RelatedToType.SELF },
   ...OtherRelatedToArrayItems[]
 ];

--- a/packages/shared/@types/indexableProperties.ts
+++ b/packages/shared/@types/indexableProperties.ts
@@ -19,11 +19,9 @@ export enum RelatedToType {
   // TASKS = "tasks",
   // ACTIVITY = "activity"
 
-
   // These are metadata and are not directly related to parent <> child relationships
   SELF = "self",
   ENTITY = "entity"
-
 }
 
 // These can be anything


### PR DESCRIPTION
This is using the prefix ID but saves us from scanning unecessary index keys when trying to get all users